### PR TITLE
DMA fixes for ESP32-C3

### DIFF
--- a/gc9a01.c
+++ b/gc9a01.c
@@ -13,7 +13,7 @@
 #include "driver/ledc.h"
 
 #include "sdkconfig.h"
-#include "GC9A01.h"
+#include "gc9a01.h"
 
 #if (CONFIG_GC9A01_RESET_USED)
 #define RESET_HIGH()           gpio_set_level(CONFIG_GC9A01_PIN_NUM_RST,1)
@@ -502,7 +502,7 @@ void gc9a01_SPI_init(void)
         .pre_cb=lcd_spi_pre_transfer_callback,
     };
 
-    ret=spi_bus_initialize(LCD_HOST,&buscfg,2);
+    ret=spi_bus_initialize(LCD_HOST,&buscfg,SPI_DMA_CH_AUTO);
     ESP_ERROR_CHECK(ret);
 
     ret=spi_bus_add_device(LCD_HOST,&devcfg,&spi);


### PR DESCRIPTION
Thanks for the driver!

I have tried it with a ESP32-C3, and came across some issues. This PR should fix them.

What has changed:
* change the type of the screen buffer to `DMA_ATTR` instead of `static` to ensure that the memory is DMA capable (see https://docs.espressif.com/projects/esp-idf/en/v4.4.1/esp32c3/api-guides/memory-types.html?highlight=dma_attr#dma-capable-requirement ).
* The ESP32-C3 DMA only works when set to `SPI_DMA_CH_AUTO`. I think this should work for other ESP's as well, but I can't test that myself. An alternative would be add an option to select between the DMA channels if auto does not work everywhere.
* The screen buffer is larger than the max SPI DMA transfer size, so transmissions are now split when they exceed this maximum.
